### PR TITLE
Build phase grid (in-progress)

### DIFF
--- a/source/SSBGameScene.cpp
+++ b/source/SSBGameScene.cpp
@@ -33,9 +33,9 @@ using namespace cugl::audio;
 #define SCENE_ASPECT 9.0/16.0
 
 /** Width of the game world in Box2d units */
-#define DEFAULT_WIDTH   32.0f
+#define DEFAULT_WIDTH   20.0f
 /** Height of the game world in Box2d units */
-#define DEFAULT_HEIGHT  18.0f
+#define DEFAULT_HEIGHT  12.0f
 
 // Since these appear only once, we do not care about the magic numbers.
 // In an actual game, this information would go in a data file.
@@ -45,7 +45,7 @@ using namespace cugl::audio;
 #define WALL_COUNT  1
 
 float WALL[WALL_COUNT][WALL_VERTS] = {
-    { 0.0f, 1.0f, 0.0f, 0.0f, 32.0f, 0.0f, 32.0f, 1.0f }
+    { 0.0f, 1.0f, 0.0f, 0.0f, 20.0f, 0.0f, 20.0f, 1.0f }
 };
 
 ///** The number of platforms */
@@ -58,7 +58,7 @@ float WALL[WALL_COUNT][WALL_VERTS] = {
 //};
 
 /** The goal door position */
-float GOAL_POS[] = { 30.0f, 1.5f };
+float GOAL_POS[] = { 18.0f, 1.5f };
 /** The initial position of the dude */
 float DUDE_POS[] = { 2.5f, 5.0f};
 
@@ -260,14 +260,23 @@ bool GameScene::init(const std::shared_ptr<AssetManager>& assets,
     _rightnode->setScale(0.35f);
     _rightnode->setVisible(false);
 
+    _gridnode = scene2::SceneNode::alloc();
+    _gridnode->setScale(_scale);
+    _gridnode->setAnchor(Vec2::ANCHOR_BOTTOM_LEFT);
+    _gridnode->setPosition(offset);
+    _gridnode->setVisible(true);
+
     addChild(_worldnode);
     addChild(_debugnode);
     addChild(_winnode);
     addChild(_losenode);
     addChild(_leftnode);
     addChild(_rightnode);
+    addChild(_gridnode);
 
     populate();
+    initGrid();
+
     _active = true;
     _complete = false;
     setDebug(false);
@@ -275,6 +284,52 @@ bool GameScene::init(const std::shared_ptr<AssetManager>& assets,
     // XNA nostalgia
     Application::get()->setClearColor(Color4f::CORNFLOWER);
     return true;
+}
+
+/**
+ * Initializes the grid layout on the screen for build mode.
+ */
+void GameScene::initGrid() {
+    const int GRID_ROWS = DEFAULT_HEIGHT;
+    const int GRID_COLS = DEFAULT_WIDTH;
+    const float CELL_SIZE = 1.0f;
+    const std::shared_ptr<Texture> EARTH_IMAGE = _assets->get<Texture>(EARTH_TEXTURE);
+
+    _gridnode->removeAllChildren();
+
+    std::shared_ptr<scene2::GridLayout> gridLayout = scene2::GridLayout::alloc();
+
+    for (int row = 0; row < GRID_ROWS; ++row) {
+        for (int col = 0; col < GRID_COLS; ++col) {
+            Vec2 cellPos(col * CELL_SIZE, row * CELL_SIZE);
+
+            std::shared_ptr<scene2::WireNode> cellNode = scene2::WireNode::allocWithPath(Rect(cellPos, Size(CELL_SIZE, CELL_SIZE)));
+            cellNode->setColor(Color4::WHITE);
+            cellNode->setAnchor(Vec2::ANCHOR_BOTTOM_LEFT);
+            cellNode->setPosition(cellPos);
+
+            std::shared_ptr<scene2::SpriteNode> spriteNode = scene2::SpriteNode::allocWithSheet(EARTH_IMAGE, 1, 1);
+            spriteNode->setAnchor(Vec2::ANCHOR_BOTTOM_LEFT);
+            spriteNode->setPosition(cellPos);
+            spriteNode->setContentSize(Size(CELL_SIZE, CELL_SIZE));
+
+            std::shared_ptr<scene2::Button> cellButton = scene2::Button::alloc(cellNode);
+            cellButton->setAnchor(Vec2::ANCHOR_BOTTOM_LEFT);
+            cellButton->setPosition(cellPos);
+            cellButton->setName("grid" + std::to_string(row) + std::to_string(col));
+            cellButton->activate();
+
+            // TODO: Fix this
+            cellButton->addListener([this](const std::string& name, bool down) {
+                if (down) {
+                    auto button = _gridnode->getChildByName(name);
+                    button->setColor(Color4::RED);
+                }
+            });
+
+            _gridnode->addChild(cellButton);
+        }
+    }
 }
 
 /**
@@ -424,8 +479,9 @@ void GameScene::populate() {
     addObstacle(_avatar,sprite); // Put this at the very front
 
     // Play the background music on a loop.
-    std::shared_ptr<Sound> source = _assets->get<Sound>(GAME_MUSIC);
-    AudioEngine::get()->getMusicQueue()->play(source, true, MUSIC_VOLUME);
+    // TODO: Uncomment for music
+//    std::shared_ptr<Sound> source = _assets->get<Sound>(GAME_MUSIC);
+//    AudioEngine::get()->getMusicQueue()->play(source, true, MUSIC_VOLUME);
 }
 
 /**

--- a/source/SSBGameScene.h
+++ b/source/SSBGameScene.h
@@ -46,6 +46,8 @@ protected:
     std::shared_ptr<scene2::PolygonNode> _leftnode;
     /** Reference to the right joystick image */
     std::shared_ptr<scene2::PolygonNode> _rightnode;
+    /** Reference to build mode grid */
+    std::shared_ptr<scene2::SceneNode> _gridnode;
 
     /** The Box2D world */
     std::shared_ptr<physics2::ObstacleWorld> _world;
@@ -178,7 +180,12 @@ public:
      */
     bool init(const std::shared_ptr<AssetManager>& assets,
               const Rect& rect, const Vec2& gravity);
-    
+
+    /**
+     * Initializes the grid layout on the screen for build mode.
+     */
+    void initGrid();
+
     
 #pragma mark -
 #pragma mark State Access


### PR DESCRIPTION
- Adjusted default width and height values to scale the game bigger
- Adjust obstacle positions to support the new width and height
- Created a function that initializes a grid to the screen
- `_gridnode` contains the grid