### PR TITLE
Slinging Mechanic

### DIFF
--- a/source/SSBDudeModel.cpp
+++ b/source/SSBDudeModel.cpp
@@ -225,9 +225,10 @@ void DudeModel::applyForce() {
             vel.x = 0; // If you set y, you will stop a jump in place
             _body->SetLinearVelocity(vel);
         } else {
-            // Damping factor in the air
-            b2Vec2 force(-getDamping()*getVX(),0);
-            _body->ApplyForce(force,_body->GetPosition(),true);
+            // Damping factor in the air 
+            // I REMOVED THIS to make slinging functional.
+            //b2Vec2 force(-getDamping()*getVX(),0);
+            //_body->ApplyForce(force,_body->GetPosition(),true);
         }
     }
     

--- a/source/SSBGameScene.cpp
+++ b/source/SSBGameScene.cpp
@@ -284,6 +284,15 @@ bool GameScene::init(const std::shared_ptr<AssetManager>& assets,
     _active = true;
     _complete = false;
     setDebug(false);
+
+    // Initializing _pathNode - this will get removed and replaced as soon as trajectory is drawn
+    _pathNode = cugl::scene2::PathNode::allocWithPath(std::vector<Vec2>{Vec2(0, 0), Vec2(1, 1)}, 1);
+    _pathNode->setName("trajectory");
+    addChild(_pathNode);
+
+    _pathNode2 = cugl::scene2::PathNode::allocWithPath(std::vector<Vec2>{Vec2(0, 0), Vec2(1, 1)}, 1);
+    _pathNode2->setName("trajectory2");
+    addChild(_pathNode2);
     
     // XNA nostalgia
     Application::get()->setClearColor(Color4f::CORNFLOWER);
@@ -707,6 +716,99 @@ void GameScene::preUpdate(float dt) {
     if (_avatar->isJumping() && _avatar->isGrounded()) {
         std::shared_ptr<Sound> source = _assets->get<Sound>(JUMP_EFFECT);
         AudioEngine::get()->play(JUMP_EFFECT,source,false,EFFECT_VOLUME);
+    }
+
+    if (_input.didReleaseFinger()) {
+        Vec2 coords = screenToWorldCoords(_input.finalPosition);
+        coords = Vec2(coords.x * 20 / 1024, coords.y * 12 / 576);
+        // using two values, calculate force in opposite direction and apply linear impulse
+        if (_slingInProgress) {
+            // Some placeholder code to get the job done - eventually refactor
+            std::vector<Vec2> vertices{
+            Vec2(0, 0), Vec2(-1, -1)
+            };
+            _trajectoryPath = Path2(vertices);
+            SimpleExtruder extruder;
+            extruder.set(_trajectoryPath);
+            extruder.calculate(5);
+            _trajectoryPoly = extruder.getPolygon();
+
+            Poly2 copy = _trajectoryPoly;
+            copy /= 50;
+            removeChild(getChildByName("trajectory"));
+            removeChild(getChildByName("trajectory2"));
+            _pathNode->setAnchor(Vec2::ANCHOR_CENTER);
+            _pathNode->setPosition(-100, -100);
+            _pathNode->setName("trajectory");
+            addChild(_pathNode);
+            _pathNode2->setAnchor(Vec2::ANCHOR_CENTER);
+            _pathNode2->setPosition(-100, -100);
+            _pathNode2->setName("trajectory2");
+            addChild(_pathNode2);
+            _slingInProgress = false;
+            Vec2 origPos(screenToWorldCoords(_input.originalPosition).x * 20 / 1024, screenToWorldCoords(_input.originalPosition).y * 12 / 576);
+            _avatar->getBody()->ApplyLinearImpulseToCenter(b2Vec2((origPos - coords).x, (origPos - coords).y), true);
+            // This causes a sliding issue if you launch horizontally.
+            // But if you remove it, the damping code (vel.x = 0) will take effect immediately.
+            // That breaks the sling.
+            _avatar->setGrounded(false);
+        }
+        
+    }
+
+    if (_slingInProgress) {
+        // TODO: Recalculate the trajectory line
+        SimpleExtruder extruder;
+        Vec2 origPos(screenToWorldCoords(_input.originalPosition).x, screenToWorldCoords(_input.originalPosition).y);
+        Vec2 finalPos(screenToWorldCoords(_input.finalPosition).x, screenToWorldCoords(_input.finalPosition).y);
+        std::vector<Vec2> vertices{
+            origPos,
+            -(origPos - finalPos) + origPos
+                };
+        _trajectoryPath = Path2(vertices);
+        extruder.set(_trajectoryPath);
+        extruder.calculate(5);
+        _trajectoryPoly = extruder.getPolygon();
+
+        Poly2 copy = _trajectoryPoly;
+        copy /= 50;
+        CULog("%f %f %f %f", _input.originalPosition.x, _input.originalPosition.y,
+            _input.finalPosition.x, _input.finalPosition.y
+        );
+
+        _pathNode = cugl::scene2::PathNode::allocWithPath(_trajectoryPath, 5);
+        removeChild(getChildByName("trajectory"));
+        _pathNode->setAnchor(Vec2::ANCHOR_CENTER);
+        _pathNode->setPosition(_avatar->getPosition().x / 20 * 1024 + (origPos - finalPos).x / 2.0f + 128,
+                                _avatar->getPosition().y / 12 * 576 + (origPos - finalPos).y / 2.0f);
+        _pathNode->setName("trajectory");
+        addChild(_pathNode);
+
+        _pathNode2 = cugl::scene2::PathNode::allocWithPath(_trajectoryPath, 5);
+        removeChild(getChildByName("trajectory2"));
+        _pathNode2->setAnchor(Vec2::ANCHOR_CENTER);
+        _pathNode2->setPosition(origPos + (origPos - finalPos) / 2.0f);
+        _pathNode2->setName("trajectory2");
+        addChild(_pathNode2);
+        
+        /*PolygonObstacle polyOb;
+        std::shared_ptr<cugl::physics2::PolygonObstacle> _center = polyOb.alloc(copy);
+        _center->setBodyType(b2_staticBody);
+        _center->setPosition(Vec2(getSize() / (100)));
+
+        _world->addObstacle(_center);*/
+
+    }
+
+    if (_input.didPressFinger()) {
+        Vec2 coords = screenToWorldCoords(_input.getMTouchPosition());
+        coords = Vec2(coords.x * 20 / 1024, coords.y * 12 / 576);
+        Vec2 pos = _avatar->getPosition();
+        // If statement will eventually be < some threshold to make sure slinging swipe starts near player
+        // Here right now as a filler
+        if ((coords - pos).length() > 0) {
+            _slingInProgress = true;
+        }
     }
 
     

--- a/source/SSBGameScene.h
+++ b/source/SSBGameScene.h
@@ -66,6 +66,16 @@ protected:
 
     std::shared_ptr<Platform> _platformTest;
 
+    /** Whether the player is currently in the middle of a sling */
+    bool _slingInProgress;
+
+    cugl::Path2 _trajectoryPath;
+
+    cugl::Poly2 _trajectoryPoly;
+
+    std::shared_ptr<cugl::scene2::SceneNode>  _pathNode;
+
+    std::shared_ptr<cugl::scene2::SceneNode>  _pathNode2;
     /** Whether we have completed this "game" */
     bool _complete;
     /** Whether or not debug mode is active */

--- a/source/SSBInput.h
+++ b/source/SSBInput.h
@@ -57,6 +57,15 @@ private:
     bool  _keyLeft;
     /** Whether the right arrow key is down */
     bool  _keyRight;
+    /** Whether the touch is currently down */
+    bool _currDown;
+    /** Whether the touch was down one frame ago */
+    bool _prevDown;
+
+    bool _prev2Down;
+public: 
+    cugl::Vec2 originalPosition;
+    cugl::Vec2 finalPosition;
   
 protected:
     // INPUT RESULTS
@@ -115,6 +124,8 @@ protected:
 	cugl::Rect _lzone;
 	/** The bounds of the right touch zone */
 	cugl::Rect _rzone;
+
+    cugl::Vec2 _touchReleasePos;
 
 	// Each zone can have only one touch
 	/** The current touch location for the left zone */
@@ -247,7 +258,18 @@ public:
      * the OS, we may see multiple updates of the same touch in a single animation
      * frame, so we need to accumulate all of the data together.
      */
-    void  update(float dt);
+    void update(float dt);
+
+    /** Returns the position of the current touch in the middle/bottom zone. 
+    */
+
+    cugl::Vec2 getMTouchPosition() const {
+        return _mtouch.position;
+    }
+
+    cugl::Vec2 getTouchReleasePosition() const {
+        return _touchReleasePos;
+    }
 
     /**
      * Clears any buffered inputs so that we may start fresh.
@@ -285,6 +307,20 @@ public:
      * @return true if the reset button was pressed.
      */
 	bool didReset() const { return _resetPressed; }
+
+    /**
+     * Returns true if the screen was just touched.
+     *
+     * @return true if the screen was just touched.
+     */
+    bool didPressFinger() const { return _currDown && !_prev2Down; }
+
+    /**
+     * Returns true if the touch was just released.
+     *
+     * @return true if the touch was just released.
+     */
+    bool didReleaseFinger() const { return _prev2Down && !_currDown; }
 
     /**
      * Returns true if the player wants to go toggle the debug mode.


### PR DESCRIPTION
You can now sling using the touch screen (no mouse support, sorry) by swiping in the middle. Hold down, drag in the opposite direction to where you want to sling (like a slingshot), and then release to launch.
- Code is temporary and messy, and trajectory vector is a little awkward in an attempt to limit the maximum sling power. Should be improved later if we keep this mechanic.
- Also, currently slinging horizontally results in a frictionless slide - should also be fixed later.