### PR TITLE
Build mode grid updates

### DIFF
--- a/source/BuildPhaseController.cpp
+++ b/source/BuildPhaseController.cpp
@@ -153,7 +153,7 @@ void BuildPhaseController::preUpdate(float dt) {
                     CULog("Selected existing object");
                     _selectedObject = obj;
                     _selectedItem = obj->getItemType();
-                    
+
                     // Set the current position of the object
                     _prevPos = _selectedObject->getPosition();
 
@@ -167,7 +167,7 @@ void BuildPhaseController::preUpdate(float dt) {
             Vec2 gridPos = snapToGrid(_buildPhaseScene.convertScreenToBox2d(screenPos) + dragOffset, _selectedItem);;
             
             if (_selectedObject) {
-                if (!_gridManager->canPlace(gridPos, itemToSize(_selectedItem))) {
+                if (!_gridManager->canPlace(gridPos, itemToGridSize(_selectedItem))) {
                     // Move the object back to its original position
                     _selectedObject->setPosition(_prevPos);
                     _gridManager->addMoveableObject(_prevPos, _selectedObject);
@@ -196,7 +196,7 @@ void BuildPhaseController::preUpdate(float dt) {
                 // Place new object on grid
                 Vec2 gridPos = snapToGrid(_buildPhaseScene.convertScreenToBox2d(screenPos) + dragOffset, _selectedItem);;
                 
-                if (_gridManager->canPlace(gridPos, itemToSize(_selectedItem))) {
+                if (_gridManager->canPlace(gridPos, itemToGridSize(_selectedItem))) {
                     std::shared_ptr<Object> obj = placeItem(gridPos, _selectedItem);
                     _gridManager->addMoveableObject(gridPos, obj);
                     
@@ -297,11 +297,11 @@ void BuildPhaseController::setBuildingMode(bool value) {
 std::shared_ptr<Object> BuildPhaseController::placeItem(Vec2 gridPos, Item item) {
     switch (item) {
         case (PLATFORM):
-            return _networkController->createPlatformNetworked(gridPos, Size(3,1), "log", _buildPhaseScene.getScale());
+            return _networkController->createPlatformNetworked(gridPos, itemToSize(item), "log", _buildPhaseScene.getScale());
         case (MOVING_PLATFORM):
-            return _networkController->createMovingPlatformNetworked(gridPos, Size(3, 1), gridPos + Vec2(3, 0), 1, _buildPhaseScene.getScale());
+            return _networkController->createMovingPlatformNetworked(gridPos, itemToSize(item), gridPos + Vec2(3, 0), 1, _buildPhaseScene.getScale());
         case (WIND):
-            return _objectController->createWindObstacle(gridPos, Size(1, 1), Vec2(0, 1.0), "default");
+            return _objectController->createWindObstacle(gridPos, itemToSize(item), Vec2(0, 1.0), "default");
         case (NONE):
             return nullptr;
     }
@@ -316,7 +316,7 @@ std::shared_ptr<Object> BuildPhaseController::placeItem(Vec2 gridPos, Item item)
  * @param item               The selected item being snapped to the grid
  */
 Vec2 BuildPhaseController::snapToGrid(const Vec2 &gridPos, Item item) {
-    Size offset = itemToSize(item) - Vec2(1, 1);
+    Size offset = itemToGridSize(item) - Vec2(1, 1);
 
     int xGrid = gridPos.x;
     int yGrid = gridPos.y;

--- a/source/BuildPhaseController.cpp
+++ b/source/BuildPhaseController.cpp
@@ -61,8 +61,8 @@ bool BuildPhaseController::init(const std::shared_ptr<AssetManager>& assets, std
     _buildPhaseScene.init(assets, camera);
 
     // Initalize UI Scene
-    _uiScene.init(assets);
-    
+    _uiScene.init(assets, _gridManager);
+
     std::vector<Item> inventoryItems = {PLATFORM, MOVING_PLATFORM, WIND};
     std::vector<std::string> assetNames = {LOG_TEXTURE, GLIDING_LOG_TEXTURE, WIND_TEXTURE};
     _uiScene.initInventory(inventoryItems, assetNames);

--- a/source/BuildPhaseUIScene.cpp
+++ b/source/BuildPhaseUIScene.cpp
@@ -71,7 +71,7 @@ void BuildPhaseUIScene::dispose() {
  *
  * @return true if the controller is initialized properly, false otherwise.
  */
-bool BuildPhaseUIScene::init(const std::shared_ptr<AssetManager>& assets) {
+bool BuildPhaseUIScene::init(const std::shared_ptr<AssetManager>& assets, std::shared_ptr<GridManager> gridManager) {
     if (assets == nullptr)
     {
         return false;
@@ -82,6 +82,7 @@ bool BuildPhaseUIScene::init(const std::shared_ptr<AssetManager>& assets) {
     }
 
     _assets = assets;
+    _gridManager = gridManager;
 
     std::shared_ptr<scene2::PolygonNode> rightNode = scene2::PolygonNode::allocWithTexture(_assets->get<Texture>(READY_BUTTON));
     rightNode->setScale(0.8f);
@@ -112,6 +113,7 @@ bool BuildPhaseUIScene::init(const std::shared_ptr<AssetManager>& assets) {
     _readyButton->addListener([this](const std::string &name, bool down) {
         if (down && !_isReady) {
             setIsReady(true);
+            _gridManager->posToObjMap.clear();  // Disables movement of placed objects
         }
     });
 

--- a/source/BuildPhaseUIScene.h
+++ b/source/BuildPhaseUIScene.h
@@ -34,6 +34,8 @@ class BuildPhaseUIScene : public scene2::Scene2 {
 protected:
     /** The asset manager for this game mode. */
     std::shared_ptr<AssetManager> _assets;
+    /** The grid manager */
+    std::shared_ptr<GridManager> _gridManager;
 
     /** Reference to the background of the inventory */
     std::shared_ptr<scene2::PolygonNode> _inventoryBackground;
@@ -86,7 +88,7 @@ public:
      *
      * @return true if the controller is initialized properly, false otherwise.
      */
-    bool init(const std::shared_ptr<AssetManager>& assets);
+    bool init(const std::shared_ptr<AssetManager>& assets, std::shared_ptr<GridManager> gridManager);
 
     /**
      * Initializes the grid layout on the screen for build mode.

--- a/source/Constants.cpp
+++ b/source/Constants.cpp
@@ -54,7 +54,7 @@ std::string itemToString(Item item) {
 }
 
 /**
- * Gets the default size of this Item..
+ * Gets the default size of this Item.
  */
 cugl::Size itemToSize(Item item) {
     switch (item) {
@@ -62,6 +62,23 @@ cugl::Size itemToSize(Item item) {
             return cugl::Size(3, 1);
         case MOVING_PLATFORM:
             return cugl::Size(3, 1);
+        case WIND:
+            return cugl::Size(1, 1);
+        case NONE:
+            return cugl::Size(1, 1);
+    }
+}
+
+/**
+ * Gets the grid size of this item.
+ * e.g. if the obstacle moves, the size will account for entire width/height of its movement as well.
+ */
+cugl::Size itemToGridSize(Item item) {
+    switch (item) {
+        case PLATFORM:
+            return cugl::Size(3, 1);
+        case MOVING_PLATFORM:
+            return cugl::Size(6, 1);
         case WIND:
             return cugl::Size(1, 1);
         case NONE:

--- a/source/Constants.h
+++ b/source/Constants.h
@@ -203,6 +203,12 @@ std::string itemToString(Item item);
 cugl::Size itemToSize(Item item);
 
 /**
+ * Gets the grid size of this item.
+ * e.g. if the obstacle moves, the size will account for entire width/height of its movement as well.
+ */
+cugl::Size itemToGridSize(Item item);
+
+/**
  * Returns the corresponding asset name to the item.
  *
  * @return the item's asset name

--- a/source/MovePhaseScene.cpp
+++ b/source/MovePhaseScene.cpp
@@ -103,6 +103,7 @@ bool MovePhaseScene::init(const std::shared_ptr<AssetManager>& assets, const std
 
     _assets = assets;
     _world = world;
+    _gridManager = gridManager;
     _networkController = networkController;
     _network = networkController->getNetwork();
     _initialCameraPos = getCamera()->getPosition();
@@ -165,6 +166,8 @@ void MovePhaseScene::populate() {
     vector<shared_ptr<Object>> levelObjs = level->createLevelFromJson("json/test2.json");
     for (auto& obj : levelObjs) {
         _objectController->processLevelObject(obj);
+        _gridManager->addObject(obj);
+        CULog("new object position: (%f, %f)", obj->getPosition().x, obj->getPosition().y);
     }
     //level->createJsonFromLevel("level2ndTest.json", level->getLevelSize(), theObjects);
 

--- a/source/MovePhaseScene.h
+++ b/source/MovePhaseScene.h
@@ -34,6 +34,7 @@ protected:
     /** The Box2D world */
     std::shared_ptr<cugl::physics2::distrib::NetWorld> _world;
     std::shared_ptr<ObjectController> _objectController;
+    std::shared_ptr<GridManager> _gridManager;
     /** The network controller */
     std::shared_ptr<NetworkController> _networkController;
     /** The network  */

--- a/source/NetworkController.cpp
+++ b/source/NetworkController.cpp
@@ -199,7 +199,7 @@ std::shared_ptr<Object> NetworkController::createPlatformNetworked(Vec2 pos, Siz
     // Check if the cast was successful
     if (boxObstacle) {
         // Assign the boxObstacle that was made to the platform
-        std::shared_ptr<Platform> plat = Platform::alloc(pos + size/2, size, boxObstacle);
+        std::shared_ptr<Platform> plat = Platform::alloc(pos, size, boxObstacle);
         _objects->push_back(plat);
         return plat;
     } else {
@@ -215,15 +215,15 @@ std::shared_ptr<Object> NetworkController::createPlatformNetworked(Vec2 pos, Siz
  */
 std::shared_ptr<Object> NetworkController::createMovingPlatformNetworked(Vec2 pos, Size size, Vec2 end, float speed, float scale) {
     
-    auto params = _movingPlatFact->serializeParams(pos+ size/2, size, end+ size/2, speed, scale);
-    
+    auto params = _movingPlatFact->serializeParams(pos + size/2, size, end + size/2, speed, scale);
+
     auto pair = _network->getPhysController()->addSharedObstacle(_movingPlatFactID, params);
 
     // Attempt to cast the obstacle to a BoxObstacle.
     auto boxObstacle = std::dynamic_pointer_cast<cugl::physics2::BoxObstacle>(pair.first);
     std::shared_ptr<scene2::SceneNode> sprite = pair.second;
     if (boxObstacle) {
-        std::shared_ptr<Platform> plat = Platform::allocMoving(pos+ size/2, size, pos+ size/2, end+ size/2, speed, boxObstacle);
+        std::shared_ptr<Platform> plat = Platform::allocMoving(pos, size, pos, end, speed, boxObstacle);
         _objects->push_back(plat);
         return plat;
     } else {

--- a/source/ObjectController.cpp
+++ b/source/ObjectController.cpp
@@ -287,6 +287,7 @@ void ObjectController::addObstacle(const std::shared_ptr<physics2::Obstacle> &ob
             weak->setAngle(obs->getAngle()); });
     }
 }
+
 void ObjectController::processLevelObject(std::shared_ptr<Object> obj) {
     std::string key = obj->getJsonKey();
 

--- a/source/ObjectController.h
+++ b/source/ObjectController.h
@@ -138,13 +138,16 @@ public:
     void addObstacle(const std::shared_ptr<physics2::Obstacle>& obj,
                          const std::shared_ptr<scene2::SceneNode>& node,
                          bool useObjPosition=true);
+
     /**called in Game Scene to create the corresponding object type
     @param obj    The physics object to add
      **/
     void processLevelObject(std::shared_ptr<Object> obj);
+
     void setNetworkController(std::shared_ptr<NetworkController> networkController) {
         _networkController = networkController;
     }
+
     std::shared_ptr<Treasure> getTreasure() {return _treasure;}
     
 

--- a/source/Platform.cpp
+++ b/source/Platform.cpp
@@ -19,7 +19,7 @@ void Platform::setPosition(const cugl::Vec2& position) {
 void Platform::update(float timestep) {
     if (!_moving) return;
     Vec2 pos = _box->getPosition();
-    Vec2 target = _forward ? _endPos- _size/2 : _startPos-_size/2;
+    Vec2 target = _forward ? _endPos+_size/2 : _startPos+_size/2;
     Vec2 toTarget = target - pos;
     float distance = toTarget.length();
 //    CULog("Pos:(%.2f, %.2f) Target:(%.2f, %.2f) Dist:%.2f Speed:%.2f Forward:%d",
@@ -27,8 +27,8 @@ void Platform::update(float timestep) {
 
 
     Vec2 direction = toTarget;
-            direction.normalize();
-            Vec2 step = direction * (_speed * timestep);
+    direction.normalize();
+    Vec2 step = direction * (_speed * timestep);
 
     //if next step will move over the end_pos
     if (distance < _speed * timestep || toTarget.dot(_box->getLinearVelocity() * timestep) < 0) {
@@ -36,7 +36,7 @@ void Platform::update(float timestep) {
         pos = target;
         _box->setPosition(pos);
         _forward = !_forward;
-        Vec2 newTarget = _forward ? _endPos-_size/2 : _startPos-_size/2;
+        Vec2 newTarget = _forward ? _endPos+_size/2 : _startPos+_size/2;
         Vec2 direction = newTarget - pos;
         direction.normalize();         
         Vec2 velocity = direction * _speed;
@@ -71,7 +71,7 @@ bool Platform::init(const Vec2 pos, const Size size) {
 }
 bool Platform::init(const Vec2 pos, const Size size, string jsonType) {
     Size nsize = size;
-    _box = cugl::physics2::BoxObstacle::alloc(pos, Size(nsize.width, nsize.height));
+    _box = cugl::physics2::BoxObstacle::alloc(pos + size/2, Size(nsize.width, nsize.height));
     _size = size;
     _itemType = Item::PLATFORM;
     _jsonType = jsonType;
@@ -96,7 +96,7 @@ bool Platform::initMoving(const Vec2 pos, const Size size, const Vec2 start, con
     if (!init(pos, size)) return false;
     _moving = true;
     _startPos = start;
-    _endPos   = end+ Vec2(size.width/2, size.height/2);
+    _endPos   = end;
     _speed    = speed;
     _forward  = true;
     _position = pos;

--- a/source/Platform.h
+++ b/source/Platform.h
@@ -49,12 +49,12 @@ public:
     */
     static std::shared_ptr<Platform> alloc(const Vec2 position, const Size size, string jsonType) {
         std::shared_ptr<Platform> result = std::make_shared<Platform>();
-        return (result->init(position + size/2, size, jsonType) ? result : nullptr);
+        return (result->init(position, size, jsonType) ? result : nullptr);
     }
 
     static std::shared_ptr<Platform> alloc(const Vec2 position, const Size size) {
         std::shared_ptr<Platform> result = std::make_shared<Platform>();
-        return (result->init(position + size/2, size) ? result : nullptr);
+        return (result->init(position, size) ? result : nullptr);
     }
     
     static std::shared_ptr<Platform> alloc(const Vec2 position, const Size size, std::shared_ptr<cugl::physics2::BoxObstacle> box) {
@@ -65,11 +65,11 @@ public:
     // New alloc method for moving platform.
     static std::shared_ptr<Platform> allocMoving(const Vec2 position, const Size size, const Vec2 start, const Vec2 end, float speed) {
         std::shared_ptr<Platform> result = std::make_shared<Platform>();
-        return (result->initMoving(position + size/2, size, start + size/2, end, speed) ? result : nullptr);
+        return (result->initMoving(position, size, start, end, speed) ? result : nullptr);
     }
     static std::shared_ptr<Platform> allocMoving(const Vec2 position, const Size size, const Vec2 start, const Vec2 end, float speed, std::shared_ptr<cugl::physics2::BoxObstacle> box) {
         std::shared_ptr<Platform> result = std::make_shared<Platform>();
-        return (result->initMoving(position + size/2, size, start + size/2, end+size/2, speed, box) ? result : nullptr);
+        return (result->initMoving(position, size, start, end, speed, box) ? result : nullptr);
     }
 
 

--- a/source/SSBGridManager.cpp
+++ b/source/SSBGridManager.cpp
@@ -98,12 +98,30 @@ void GridManager::setSpriteInvisible(){
 #pragma mark Object Handling
 
 /**
- * Adds the object to the object map to this location.
+ * Adds the non-moveable object's position to the position has object map.
+ *
+ *@param obj    the object
+ */
+void GridManager::addObject(std::shared_ptr<Object> obj) {
+    Vec2 cellPos = obj->getPosition();
+
+    // Add the object to every position it exists in
+    for (int i = 0; i < obj->getSize().getIWidth(); i++) {
+        for (int j = 0; j < obj->getSize().getIHeight(); j++) {
+            // TODO: Check if the y-axis offset is positive or negative
+            auto posPair = std::make_pair(cellPos.x + i, cellPos.y + j);
+            hasObjMap[posPair] = true;
+        }
+    }
+};
+
+/**
+ * Adds the moveable object to the object map to this location.
  *
  *@param cellPos    the cell position
  *@param obj    the object
  */
-void GridManager::addObject(Vec2 cellPos, std::shared_ptr<Object> obj) {
+void GridManager::addMoveableObject(Vec2 cellPos, std::shared_ptr<Object> obj) {
     auto originPosPair = std::make_pair(cellPos.x, cellPos.y);
 
     std::string x = std::to_string(cellPos.x);
@@ -111,7 +129,7 @@ void GridManager::addObject(Vec2 cellPos, std::shared_ptr<Object> obj) {
     CULog("%s", x.c_str());
     CULog("%s", y.c_str());
     // Add the origin position of the object
-    objToOriginPosMap[obj] = originPosPair;
+    objToPosMap[obj] = originPosPair;
 
     // Add the object to every position it exists in
     for (int i = 0; i < obj->getSize().getIWidth(); i++) {
@@ -119,19 +137,20 @@ void GridManager::addObject(Vec2 cellPos, std::shared_ptr<Object> obj) {
             // TODO: Check if the y-axis offset is positive or negative
             auto posPair = std::make_pair(cellPos.x + i, cellPos.y + j);
             posToObjMap[posPair] = obj;
+            hasObjMap[posPair] = true;
         }
     }
 };
 
 /**
- * Removes the object from the object map, if it exists.
+ * Removes the moveable object from the object map, if it exists.
  *
  *@return   the object removed, or `nullptr` if it does not exist.
  *
  *@param cellPos    the cell position
  *@param col    the cell column to add the object to
  */
-std::shared_ptr<Object> GridManager::removeObject(Vec2 cellPos) {
+std::shared_ptr<Object> GridManager::moveObject(Vec2 cellPos) {
     // Find object in object map
     auto posPair = std::make_pair(cellPos.x, cellPos.y);
 
@@ -142,42 +161,45 @@ std::shared_ptr<Object> GridManager::removeObject(Vec2 cellPos) {
     }
 
     std::shared_ptr<Object> obj = it->second;
-    // TODO: Remove this
-//    posToObjectMap.erase(it);
 
     // Clear all positions the object occupies
-    auto originPosX = objToOriginPosMap[obj].first;
-    auto originPosY = objToOriginPosMap[obj].second;
+    auto originPosX = objToPosMap[obj].first;
+    auto originPosY = objToPosMap[obj].second;
 
     for (int i = 0; i < obj->getSize().getIWidth(); i++) {
         for (int j = 0; j < obj->getSize().getIHeight(); j++) {
             // TODO: Check if the y-axis offset is positive or negative
             auto posPair = std::make_pair(originPosX + i, originPosY + j);
             posToObjMap.erase(posPair);
+            hasObjMap.erase(posPair);
         }
     }
 
     // Clear the origin position of the object
-    objToOriginPosMap.erase(obj);
+    objToPosMap.erase(obj);
 
     return obj;
 };
 
 /**
- * Checks if there's an object in this grid position.
+ * Checks whether we can place the object in the cell position.
  *
- * @return true if there exists an object
+ * @return false if there exists an object
  *
  * @param cellPos    the cell position
+ * @param size          the size of the object being placed
  */
-bool GridManager::hasObject(Vec2 cellPos) {
-    // Find object in object map
-    auto posPair = std::make_pair(cellPos.x, cellPos.y);
+bool GridManager::canPlace(Vec2 cellPos, Size size) {
+    for (int i = 0; i < size.getIWidth(); i++) {
+        for (int j = 0; j < size.getIHeight(); j++) {
+            // Find object in object map
+            auto posPair = std::make_pair(cellPos.x + i, cellPos.y + j);
 
-    auto it = posToObjMap.find(posPair);
-    if (it == posToObjMap.end()) {
-        // If unable to find object
-        return false;
+            if (hasObjMap.find(posPair) != hasObjMap.end()) {
+                // If unable to find object
+                return false;
+            }
+        }
     }
 
     return true;

--- a/source/SSBGridManager.cpp
+++ b/source/SSBGridManager.cpp
@@ -199,8 +199,7 @@ bool GridManager::canPlace(Vec2 cellPos, Size size) {
             auto posPair = std::make_pair(cellPos.x + i, cellPos.y + j);
 
             if (hasObjMap.find(posPair) != hasObjMap.end()) {
-                // If unable to find object
-                return false;
+                return false;   // Object exists in position
             }
         }
     }

--- a/source/SSBGridManager.cpp
+++ b/source/SSBGridManager.cpp
@@ -104,7 +104,7 @@ void GridManager::setSpriteInvisible(){
  */
 void GridManager::addObject(std::shared_ptr<Object> obj) {
     Vec2 cellPos = obj->getPosition();
-    Size size = itemToGridSize(obj->getItemType());
+    Size size = obj->getSize();
 
     // Add the object to every position it exists in
     for (int i = 0; i < size.getIWidth(); i++) {

--- a/source/SSBGridManager.cpp
+++ b/source/SSBGridManager.cpp
@@ -104,10 +104,11 @@ void GridManager::setSpriteInvisible(){
  */
 void GridManager::addObject(std::shared_ptr<Object> obj) {
     Vec2 cellPos = obj->getPosition();
+    Size size = itemToGridSize(obj->getItemType());
 
     // Add the object to every position it exists in
-    for (int i = 0; i < obj->getSize().getIWidth(); i++) {
-        for (int j = 0; j < obj->getSize().getIHeight(); j++) {
+    for (int i = 0; i < size.getIWidth(); i++) {
+        for (int j = 0; j < size.getIHeight(); j++) {
             // TODO: Check if the y-axis offset is positive or negative
             auto posPair = std::make_pair(cellPos.x + i, cellPos.y + j);
             hasObjMap[posPair] = true;
@@ -123,6 +124,7 @@ void GridManager::addObject(std::shared_ptr<Object> obj) {
  */
 void GridManager::addMoveableObject(Vec2 cellPos, std::shared_ptr<Object> obj) {
     auto originPosPair = std::make_pair(cellPos.x, cellPos.y);
+    Size size = itemToGridSize(obj->getItemType());
 
     std::string x = std::to_string(cellPos.x);
     std::string y = std::to_string(cellPos.y);
@@ -132,8 +134,8 @@ void GridManager::addMoveableObject(Vec2 cellPos, std::shared_ptr<Object> obj) {
     objToPosMap[obj] = originPosPair;
 
     // Add the object to every position it exists in
-    for (int i = 0; i < obj->getSize().getIWidth(); i++) {
-        for (int j = 0; j < obj->getSize().getIHeight(); j++) {
+    for (int i = 0; i < size.getIWidth(); i++) {
+        for (int j = 0; j < size.getIHeight(); j++) {
             // TODO: Check if the y-axis offset is positive or negative
             auto posPair = std::make_pair(cellPos.x + i, cellPos.y + j);
             posToObjMap[posPair] = obj;
@@ -161,13 +163,14 @@ std::shared_ptr<Object> GridManager::moveObject(Vec2 cellPos) {
     }
 
     std::shared_ptr<Object> obj = it->second;
+    Size size = itemToGridSize(obj->getItemType());
 
     // Clear all positions the object occupies
     auto originPosX = objToPosMap[obj].first;
     auto originPosY = objToPosMap[obj].second;
 
-    for (int i = 0; i < obj->getSize().getIWidth(); i++) {
-        for (int j = 0; j < obj->getSize().getIHeight(); j++) {
+    for (int i = 0; i < size.getIWidth(); i++) {
+        for (int j = 0; j < size.getIHeight(); j++) {
             // TODO: Check if the y-axis offset is positive or negative
             auto posPair = std::make_pair(originPosX + i, originPosY + j);
             posToObjMap.erase(posPair);
@@ -187,7 +190,7 @@ std::shared_ptr<Object> GridManager::moveObject(Vec2 cellPos) {
  * @return false if there exists an object
  *
  * @param cellPos    the cell position
- * @param size          the size of the object being placed
+ * @param size          the amount of area this object takes up (including its movement)
  */
 bool GridManager::canPlace(Vec2 cellPos, Size size) {
     for (int i = 0; i < size.getIWidth(); i++) {

--- a/source/SSBGridManager.h
+++ b/source/SSBGridManager.h
@@ -158,7 +158,7 @@ public:
      * @return false if there exists an object
      *
      * @param cellPos    the cell position
-     * @param size          the size of the object being placed
+     * @param size          the amount of area this object takes up (including its movement)
      */
     bool canPlace(Vec2 cellPos, Size size);
 

--- a/source/SSBGridManager.h
+++ b/source/SSBGridManager.h
@@ -21,10 +21,12 @@ using namespace cugl::graphics;
 */
 class GridManager {
 public:
-    /** Maps grid positions to world objects */
+    /** Maps grid positions to moveable world objects */
     std::map<std::pair<int, int>, std::shared_ptr<Object>> posToObjMap;
-    /** Maps world objects to bottom left position of objects */
-    std::map<std::shared_ptr<Object>, std::pair<int, int>> objToOriginPosMap;
+    /** Maps grid positions to whether there exists an object (moveable or non-moveable) that contains the grid box */
+    std::map<std::pair<int, int>, bool> hasObjMap;
+    /** Maps moveable world objects to bottom left position of objects */
+    std::map<std::shared_ptr<Object>, std::pair<int, int>> objToPosMap;
 
 private:
     /** Reference to building mode grid */
@@ -126,6 +128,12 @@ public:
 
 #pragma mark -
 #pragma mark Object Handling
+    /**
+     * Adds the non-moveable object's position to the position has object map.
+     *
+     *@param obj    the object
+     */
+    void addObject(std::shared_ptr<Object> obj);
 
     /**
      * Adds the object to the object map.
@@ -133,7 +141,7 @@ public:
      *@param cellPos    the cell position
      *@param obj    the object
      */
-    void addObject(Vec2 cellPos, std::shared_ptr<Object> obj);
+    void addMoveableObject(Vec2 cellPos, std::shared_ptr<Object> obj);
 
     /**
      * Removes the object from the object map, if it exists.
@@ -142,16 +150,17 @@ public:
      *
      *@param cellPos    the cell position
      */
-    std::shared_ptr<Object> removeObject(Vec2 cellPos);
+    std::shared_ptr<Object> moveObject(Vec2 cellPos);
 
     /**
-     * Checks if there's an object in this grid position.
+     * Checks whether we can place the object in the cell position.
      *
-     * @return true if there exists an object
+     * @return false if there exists an object
      *
      * @param cellPos    the cell position
+     * @param size          the size of the object being placed
      */
-    bool hasObject(Vec2 cellPos);
+    bool canPlace(Vec2 cellPos, Size size);
 
 };
 


### PR DESCRIPTION
- Created new methods in `GridManager` and add objects to the grid when loading them up in `MovePhaseScene` so that the player cannot place objects over any existing objects.
- Adjusted platform and moving platform placing (offset was incorrect for both).
- Prevent player from placing moving platforms where it can run into other objects by creating an `itemToGridSize` method that gets the entire size that contains the grid including movement space.
  - Note: Objects loaded in have a width and height in the json, so we have to use the `Object` size to get all the positions of each object spanning the json entry.
- Prevent objects from being moveable after build phase is over (after each round).