### PR TITLE
Temporary fix to object dragging

### DIFF
--- a/source/BuildPhaseController.cpp
+++ b/source/BuildPhaseController.cpp
@@ -329,6 +329,7 @@ std::shared_ptr<Object> BuildPhaseController::placeItem(Vec2 gridPos, Item item)
  * @param item               The selected item being snapped to the grid
  */
 Vec2 BuildPhaseController::snapToGrid(const Vec2 &gridPos, Item item) {
+    // Consider size of item
     Size offset = itemToGridSize(item) - Vec2(1, 1);
 
     int xGrid = gridPos.x;

--- a/source/BuildPhaseScene.cpp
+++ b/source/BuildPhaseScene.cpp
@@ -175,8 +175,8 @@ Vec2 BuildPhaseScene::convertScreenToBox2d(const Vec2& screenPos, float systemSc
     float yBox2D = worldPos.y / _scale;
 
     // Converts to the specific grid position
-    int xGrid = xBox2D / 2;
-    int yGrid = yBox2D / 2;
+    int xGrid = xBox2D / 2 - 1;
+    int yGrid = yBox2D / 2 + 1;
 
     return Vec2(xGrid, yGrid);
 }


### PR DESCRIPTION
Modified `convertScreenToBox2d` method in BuildPhaseScene to temporarily fix this issue. Dragging objects now works properly for mobile devices.