### PR TITLE
Bomb object fixes + moveable wind object

### DIFF
--- a/source/Bomb.cpp
+++ b/source/Bomb.cpp
@@ -62,25 +62,13 @@ bool Bomb::init(const Vec2 pos, const Size size, string jsonType) {
     _position = pos;
 
     PolyFactory factory;
-    Poly2 rect = factory.makeRect(Vec2(-0.5f, -0.5f), size);
+    Poly2 rect = factory.makeRect(Vec2(-1.25f, -1.25f), Size(2.5f, 2.5f)); // Center offset for bomb radius of size 2.5x2.5
 
     if (PolygonObstacle::init(rect)){
         setPosition(pos + size/2);
+
+        // For bomb radius
         setSensor(true);
-
-        // Create bomb radius sensor
-        b2PolygonShape sensorBox;
-        sensorBox.SetAsBox(3.0f, 3.0f);
-
-        b2FixtureDef sensorDef;
-        sensorDef.shape = &sensorBox;
-        sensorDef.isSensor = true;
-        sensorDef.userData.pointer = reinterpret_cast<uintptr_t>(this);
-
-        // Attach the sensor to the body
-        if (_body != nullptr) {
-            _body->CreateFixture(&sensorDef);
-        }
 
         return true;
     }

--- a/source/BuildPhaseController.cpp
+++ b/source/BuildPhaseController.cpp
@@ -455,7 +455,7 @@ std::shared_ptr<Object> BuildPhaseController::placeItem(Vec2 gridPos, Item item)
         case (THORN):
             return _networkController->createThornNetworked(gridPos, itemToSize(item));
         case (MUSHROOM):
-            return _networkController->createMushroomNetworked(gridPos - itemToSize(item) * 0.5f, itemToSize(item), _buildPhaseScene.getScale() / getSystemScale());
+            return _networkController->createMushroomNetworked(gridPos, itemToSize(item), _buildPhaseScene.getScale() / getSystemScale());
         case (BOMB):
             return _networkController->createBombNetworked(gridPos, itemToSize(item));
         case (TREASURE):

--- a/source/MovePhaseController.cpp
+++ b/source/MovePhaseController.cpp
@@ -538,6 +538,13 @@ void MovePhaseController::beforeSolve(b2Contact* contact, const b2Manifold* oldM
         contact->SetEnabled(false);
     }
 
+    bool isMushroom1 = dynamic_cast<Mushroom*>(obj1) != nullptr;
+    bool isMushroom2 = dynamic_cast<Mushroom*>(obj2) != nullptr;
+    // Disables player - mushroom collision (makes it passthrough)
+    if (isMushroom1 || isMushroom2) {
+        contact->SetEnabled(false);
+    }
+
     if (tagContainsPlayer(bd1->getName()) && bd1 == _movePhaseScene.getLocalPlayer().get()) {        
         if (bd2->getName() == "platform" || bd2->getName() == "movingPlatform") {
             plat = dynamic_cast<Platform*>(bd2);

--- a/source/MovePhaseController.cpp
+++ b/source/MovePhaseController.cpp
@@ -527,7 +527,17 @@ void MovePhaseController::beforeSolve(b2Contact* contact, const b2Manifold* oldM
     physics2::Obstacle* bd2 = reinterpret_cast<physics2::Obstacle*>(body2->GetUserData().pointer);
 
     Platform* plat = nullptr;
-   
+
+    Object* obj1 = reinterpret_cast<Object*>(contact->GetFixtureA()->GetBody()->GetUserData().pointer);
+    Object* obj2 = reinterpret_cast<Object*>(contact->GetFixtureB()->GetBody()->GetUserData().pointer);
+
+    bool isWind1 = dynamic_cast<WindObstacle*>(obj1) != nullptr;
+    bool isWind2 = dynamic_cast<WindObstacle*>(obj2) != nullptr;
+    // If one of the objects is wind, prevent collision (stops player from colliding with fan WITHOUT wind being a sensor)
+    if (isWind1 || isWind2) {
+        contact->SetEnabled(false);
+    }
+
     if (tagContainsPlayer(bd1->getName()) && bd1 == _movePhaseScene.getLocalPlayer().get()) {        
         if (bd2->getName() == "platform" || bd2->getName() == "movingPlatform") {
             plat = dynamic_cast<Platform*>(bd2);

--- a/source/Mushroom.cpp
+++ b/source/Mushroom.cpp
@@ -14,6 +14,24 @@ void Mushroom::dispose() {
     markRemoved(true);
 }
 
+bool Mushroom::init(const Vec2 pos, const Size size, std::string jsonType) {
+    _position = pos;
+    _size     = size;
+    _jsonType = jsonType;
+    _itemType = Item::MUSHROOM;
+
+    PolyFactory factory;
+    Poly2 rect = factory.makeRect(Vec2(-1.0f, -0.5f), size);
+    if (!PolygonObstacle::init(rect)) {
+        return false;
+    }
+
+    setPosition(pos + size * 0.5f);
+    setSensor(false);
+
+    return true;
+}
+
 bool Mushroom::init(const Vec2 pos, const Size size, float scale) {
     _position = pos;
     _size     = size;
@@ -21,36 +39,28 @@ bool Mushroom::init(const Vec2 pos, const Size size, float scale) {
     _itemType = Item::MUSHROOM;
 
     PolyFactory factory;
-    Poly2 rect = factory.makeRect(
-        Vec2(-size.width * 0.4f, -size.height * 0.5f),
-        Size(size.width * 0.8f, size.height)
-    );
+    Poly2 rect = factory.makeRect(Vec2(-1.0f, -0.5f), size);
     if (!PolygonObstacle::init(rect)) {
         return false;
     }
 
     setPosition(pos + size * 0.5f);
-    setSensor(true);
-    setDebugColor(Color4::YELLOW);
-
-    _node = scene2::SpriteNode::alloc();
-    _node->setPosition(getPosition() * _drawScale);
+    setSensor(false);
 
     return true;
 }
 
 void Mushroom::setMushroomAnimation(std::shared_ptr<scene2::SpriteNode> sprite, int nFrames) {
     _mushroomSpriteNode = sprite;
-    _mushroomSpriteNode->setAnchor(0.0f, 0.0f);
     _mushroomSpriteNode->setPosition(Vec2());
     _mushroomSpriteNode->setVisible(true);
 
-    if (!_node) {
-        _node = scene2::SpriteNode::alloc();
+    if (!_sceneNode) {
+        _sceneNode = scene2::SpriteNode::alloc();
     } else {
-        _node->removeAllChildren();
+        _sceneNode->removeAllChildren();
     }
-    _node->addChild(_mushroomSpriteNode);
+    _sceneNode->addChild(_mushroomSpriteNode);
 
     std::vector<int> frames;
     frames.reserve(nFrames);
@@ -85,12 +95,6 @@ void Mushroom::updateAnimation(float dt) {
 
 void Mushroom::update(float timestep) {
     PolygonObstacle::update(timestep);
-
-    if (_node) {
-        _node->setPosition(getPosition() * _drawScale);
-        _node->setAngle(getAngle());
-    }
-
     updateAnimation(timestep);
 }
 

--- a/source/Mushroom.h
+++ b/source/Mushroom.h
@@ -10,8 +10,7 @@ class Mushroom : public Object {
 private:
     float _drawScale = 1.0f;
     std::shared_ptr<cugl::physics2::BoxObstacle> _box;
-
-    std::shared_ptr<scene2::SceneNode> _node;
+    std::shared_ptr<cugl::physics2::PolygonObstacle> _sensor;
 
     // Animations
     std::shared_ptr<cugl::ActionTimeline>    _mushroomTimeline;
@@ -26,6 +25,7 @@ public:
     Mushroom(Vec2 pos) : Object(pos, Item::MUSHROOM) {}
     ~Mushroom(void) override { dispose(); }
 
+    bool init(const Vec2 pos, const Size size, std::string jsonType);
     bool init(const Vec2 pos, const Size size, float scale);
     void setPositionInit(const Vec2& position);
     void update(float timestep) override;
@@ -41,7 +41,12 @@ public:
     }
     void stopAnimation()    { _shouldAnimate = false; }
 
-    const std::shared_ptr<scene2::SceneNode>& getSceneNode() const { return _node; }
+    const std::shared_ptr<scene2::SceneNode>& getSceneNode() const { return _sceneNode; }
+
+    static std::shared_ptr<Mushroom> alloc(const Vec2 position, const Size size, string jsonType) {
+        std::shared_ptr<Mushroom> result = std::make_shared<Mushroom>();
+        return (result->init(position, size, jsonType) ? result : nullptr);
+    }
 
     static std::shared_ptr<Mushroom> alloc(const Vec2 position, const Size size, float scale) {
         std::shared_ptr<Mushroom> result = std::make_shared<Mushroom>();

--- a/source/NetworkController.cpp
+++ b/source/NetworkController.cpp
@@ -1134,11 +1134,7 @@ WindFactory::createObstacle(Vec2 pos, Size size,float scale, const Vec2 windDire
     gusts.push_back(animNode4);
 
     wind->setGustAnimation(gusts, 14);
-
     wind->setPositionInit(pos);
-    wind->setEnabled(false);
-
-    // IN ORDER TO NETWORK GUST ANIMIATIONS, MAY NEED TO ADD GUST SPRITE AS CHILD TO FANSPRITE --> TAKE A LOOK AT HOW PLAYER ANIMATIONS ARE SETUP IN DUDE FACTORY, ALL ANIMATIONS ARE CHILDREN OF A ROOT NODE
 
     return std::make_pair(wind, wind->getSceneNode());
 }

--- a/source/ObjectController.cpp
+++ b/source/ObjectController.cpp
@@ -8,6 +8,7 @@
 #include "SSBGameController.h"
 #include "Constants.h"
 #include "Platform.h"
+#include "Mushroom.h"
 #include "Tile.h"
 #include "Spike.h"
 #include <box2d/b2_world.h>
@@ -284,6 +285,37 @@ std::shared_ptr<Object> ObjectController::createWindObstacle(std::shared_ptr<Win
     _gameObjects->push_back(wind);
 
     return wind;
+}
+
+/**
+* Creates a new mushroom.
+*
+* @return the mushroom
+*
+* @param pos The position of the bottom left corner of the platform in Box2D coordinates.
+* @param size The dimensions (width, height) of the platform.
+*/
+std::shared_ptr<Object> ObjectController::createMushroom(Vec2 pos, Size size, float scale, std::string jsonType, bool isLevelEditorMode) {
+    std::shared_ptr<Mushroom> mush = Mushroom::alloc(pos, size, jsonType);
+    return createMushroom(mush, isLevelEditorMode);
+}
+
+std::shared_ptr<Object> ObjectController::createMushroom(std::shared_ptr<Mushroom> mush, bool isLevelEditorMode) {
+    auto animNode = scene2::SpriteNode::allocWithSheet(
+        _assets->get<Texture>(MUSHROOM_BOUNCE), 1, 9, 9
+    );
+    mush->setMushroomAnimation(animNode, 9);
+
+    mush->setDensity(BASIC_DENSITY);
+    mush->setFriction(BASIC_FRICTION);
+    mush->setRestitution(BASIC_RESTITUTION);
+    mush->setName("mushroom");
+    mush->setDebugColor(DEBUG_COLOR);
+
+    addObstacle(mush, mush->getSceneNode());
+    _gameObjects->push_back(mush);
+
+    return mush;
 }
 
 /**

--- a/source/ObjectController.cpp
+++ b/source/ObjectController.cpp
@@ -286,6 +286,38 @@ std::shared_ptr<Object> ObjectController::createWindObstacle(std::shared_ptr<Win
     return wind;
 }
 
+/**
+* Creates a new bomb.
+*
+* @return the bomb
+*
+* @param pos The position of the bottom left corner of the platform in Box2D coordinates.
+* @param size The dimensions (width, height) of the platform.
+*/
+std::shared_ptr<Object> ObjectController::createBomb(Vec2 pos, Size size, float scale, std::string jsonType, bool isLevelEditorMode) {
+    std::shared_ptr<Bomb> bomb = Bomb::alloc(pos, size, jsonType);
+    return createBomb(bomb, isLevelEditorMode);
+}
+
+std::shared_ptr<Object> ObjectController::createBomb(std::shared_ptr<Bomb> bomb, bool isLevelEditorMode) {
+    std::shared_ptr<Texture> texture = _assets->get<Texture>(BOMB_TEXTURE);
+
+    bomb->setBodyType(b2_dynamicBody);
+    bomb->setDensity(BASIC_DENSITY);
+    bomb->setFriction(BASIC_FRICTION);
+    bomb->setRestitution(BASIC_RESTITUTION);
+    bomb->setName("bomb");
+    bomb->setDebugColor(DEBUG_COLOR);
+
+    auto animNode = scene2::SpriteNode::allocWithSheet(_assets->get<Texture>(BOMB_TEXTURE_ANIMATED), 1, 14, 14);
+    bomb->setAnimation(animNode);
+
+    addObstacle(bomb, bomb->getSceneNode());
+    _gameObjects->push_back(bomb);
+
+    return bomb;
+}
+
 std::shared_ptr<Object> ObjectController::createTreasure(Vec2 pos, Size size, string jsonType, bool isLevelEditorMode){
     std::shared_ptr<Texture> image = _assets->get<Texture>("treasure");
     std::shared_ptr<Treasure> treas = Treasure::alloc(pos, image->getSize() / _scale, _scale);

--- a/source/ObjectController.h
+++ b/source/ObjectController.h
@@ -132,6 +132,18 @@ public:
    std::shared_ptr<Object> createWindObstacle(std::shared_ptr<WindObstacle> wind, bool isLevelEditorMode=false);
 
     /**
+    * Creates a new mushroom.
+    *
+    * @return the mushroom
+    *
+    * @param pos The position of the bottom left corner of the platform in Box2D coordinates.
+    * @param size The dimensions (width, height) of the platform.
+    */
+    std::shared_ptr<Object> createMushroom(Vec2 pos, Size size, float scale, std::string jsonType, bool isLevelEditorMode);
+
+    std::shared_ptr<Object> createMushroom(std::shared_ptr<Mushroom> mush, bool isLevelEditorMode);
+
+    /**
     * Creates a new bomb.
     *
     * @return the bomb

--- a/source/ObjectController.h
+++ b/source/ObjectController.h
@@ -20,6 +20,7 @@
 #include "Object.h"
 #include "Spike.h"
 #include "Tile.h"
+#include "Bomb.h"
 #include <cugl/cugl.h>
 #include <box2d/b2_world.h>
 #include <box2d/b2_body.h>
@@ -129,7 +130,19 @@ public:
    std::shared_ptr<Object> createWindObstacle(Vec2 pos, Size size, float scale, const Vec2 windDirection, const Vec2 windStrength, std::string jsonType, bool isLevelEditorMode=false);
 
    std::shared_ptr<Object> createWindObstacle(std::shared_ptr<WindObstacle> wind, bool isLevelEditorMode=false);
-    
+
+    /**
+    * Creates a new bomb.
+    *
+    * @return the bomb
+    *
+    * @param pos The position of the bottom left corner of the platform in Box2D coordinates.
+    * @param size The dimensions (width, height) of the platform.
+    */
+   std::shared_ptr<Object> createBomb(Vec2 pos, Size size, float scale, std::string jsonType, bool isLevelEditorMode=false);
+
+   std::shared_ptr<Object> createBomb(std::shared_ptr<Bomb> bomb, bool isLevelEditorMode=false);
+
     
     /** Creates a treasure
     * @param pos The position of the bottom left corner of the treasure in Box2D coordinates.

--- a/source/Platform.cpp
+++ b/source/Platform.cpp
@@ -178,10 +178,10 @@ void Platform::setPlatformAnimation(std::shared_ptr<scene2::SpriteNode> sprite, 
     _platSpriteNode->setAnchor(0.0f, 0.0f);
     _platSpriteNode->setPosition(getPosition().x - 120, getPosition().y - 32);
     _platSpriteNode->setVisible(true);
-    if (!_node) {
-        _node = scene2::SceneNode::alloc();
+    if (!_sceneNode) {
+        _sceneNode = scene2::SceneNode::alloc();
     }
-    _node->addChild(_platSpriteNode);
+    _sceneNode->addChild(_platSpriteNode);
 
     //Create the spritesheet
     _platTimeline = ActionTimeline::alloc();

--- a/source/Platform.h
+++ b/source/Platform.h
@@ -92,12 +92,11 @@ public:
     void updateAnimation(float timestep);
 
     std::shared_ptr<cugl::ActionTimeline> _platTimeline;
-    std::shared_ptr<scene2::SceneNode> _node;
     std::shared_ptr<cugl::scene2::SpriteNode> _platSpriteNode;
     std::shared_ptr<AnimateSprite> _platAnimateSprite;
     cugl::ActionFunction _platAction;
 
-    const std::shared_ptr<scene2::SceneNode>& getSceneNode() const { return _node; }
+    const std::shared_ptr<scene2::SceneNode>& getSceneNode() const { return _sceneNode; }
 };
 
 

--- a/source/WindObstacle.cpp
+++ b/source/WindObstacle.cpp
@@ -87,8 +87,13 @@ string WindObstacle::getJsonKey() {
 void WindObstacle::dispose() {
     Object::dispose();
 
+    CULog("Diposing wind");
     markRemoved(true);
-//    _gust = nullptr;
+
+    if (_node && _node->getParent()) {
+        _node->removeFromParent();
+        _node = nullptr;
+    }
 }
 
 using namespace cugl;
@@ -139,19 +144,15 @@ bool WindObstacle::init(const Vec2 pos, const Size size, float scale, const Vec2
     Poly2 rect = factory.makeRect(Vec2(-0.5f, -0.5f), size);
 
     if (PolygonObstacle::init(rect)){
-        setPosition(pos);
+        setPosition(pos + size/2);
         setDensity(0.0f);
         setFriction(0.0f);
         setRestitution(0.0f);
         setName("fan");
-        setBodyType(b2_staticBody);
-        setSensor(true);
-        setEnabled(false);
+        setBodyType(b2_dynamicBody);
         
         _node = scene2::SpriteNode::alloc();
-
         _node->setPriority(PRIORITY);
-        
 
         return true;
     }


### PR DESCRIPTION
- Fixed bomb object explosion for all placed objects.
- Fixed radius properly.
- Adjusted lots of objects nodes and disposal methods (mushrooms, wind, moving platform).
- For mushroom and wind, disabled their sensor and adjusted their hitboxes and player collisions.