### PR TITLE
Fix Crash on Quit + WindObstacle visibility

### DIFF
--- a/source/ObjectController.cpp
+++ b/source/ObjectController.cpp
@@ -395,6 +395,7 @@ std::shared_ptr<Object> ObjectController::createParallaxArtObject(std::shared_pt
     art->setFriction(BASIC_FRICTION);
     art->setRestitution(BASIC_RESTITUTION);
     art->setDebugColor(DEBUG_COLOR);
+    art->setItemType(Item::ART_OBJECT);
     art->setName("artObject");
     // Disable ArtObject collision physics
     art->setSensor(true);

--- a/source/SSBGameController.cpp
+++ b/source/SSBGameController.cpp
@@ -219,11 +219,16 @@ void SSBGameController::dispose()
     if (_gridManager) {
         _gridManager->getGridNode() = nullptr;
     }
-
-    _input->dispose();
+    if (_input != nullptr) {
+        _input->dispose();
+    }
     _backgroundScene.dispose();
-    _buildPhaseController->dispose();
-    _movePhaseController->dispose();
+    if (_buildPhaseController != nullptr) {
+        _buildPhaseController->dispose();
+    }
+    if (_movePhaseController != nullptr) {
+        _movePhaseController->dispose();
+    }
     Scene2::dispose();
 }
 

--- a/source/WindObstacle.h
+++ b/source/WindObstacle.h
@@ -10,7 +10,7 @@ constexpr int RAYS = 3;
 #define OFFSET 0.1f
 #define FAN_ANIM_CYCLE 0.8f
 #define GUST_ANIM_CYCLE 3.0f
-#define PRIORITY -900
+#define PRIORITY 0
 
 class WindObstacle : public Object {
 


### PR DESCRIPTION
- game no longer crashes if you quit during loading
- WindObstacles are now visible in front of background art